### PR TITLE
Use `html.escape` in `/chat_api` end point

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import argparse
+import html
 import os
 
 import ctranslate2
@@ -149,10 +150,9 @@ app = FastAPI()
 
 
 @app.get("/chat_api")
-async def chat(text: str = ""):
+async def chat(text: str = "") -> dict[str, list[dict[str, str]]]:
     res = engine.generate_text(text)
-    generated_text = res
-    reply = generated_text.replace("\n", "<br>")
+    reply = html.escape(res).replace("\n", "<br>")
     print(f"input:{text} reply:{reply}")
 
     outJson = {"output": [{"type": "text", "value": reply}]}
@@ -162,11 +162,11 @@ async def chat(text: str = ""):
 app.mount("/", StaticFiles(directory="html", html=True), name="html")
 
 
-def start_server():
+def start_server() -> None:
     uvicorn.run(app, host=HOST, port=PORT)
 
 
-def main():
+def main() -> None:
     start_server()
 
     # When you want to open a browser at the same time

--- a/main.py
+++ b/main.py
@@ -65,7 +65,6 @@ class ElyzaEngine(Engine):
 
     # ELYZA用生成呼び出し
     def generate_text(self, input) -> str:
-        # ELYZA用生成呼び出し
         B_INST, E_INST = "[INST]", "[/INST]"
         B_SYS, E_SYS = "<<SYS>>\n", "\n<</SYS>>\n\n"
         DEFAULT_SYSTEM_PROMPT = "あなたは誠実で優秀な日本人のアシスタントです。"


### PR DESCRIPTION
closes #3 

少し調べたら簡単に対応できそうだったので修正してみました。

<img width="395" alt="Screen Shot 2023-09-11 at 23 35 28" src="https://github.com/sotokisehiro/chatux-server-llm/assets/16088/6537279a-3b9c-4e92-8f2f-f823ec73bd2a">


Issue を読んでいただいてお手間を取らせてすみませんでした。