### PR TITLE
Docker のベースイメージを Ubuntu 23.04 に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # chatux-server-llm
 
 ローカル環境で動作する文章生成 AI チャットボットです。
-CPU だけで動作します。（NVIDIA のグラボは不要）
+
+CPU だけで動作するため NVIDIA のグラフィックスボードは不要です。
 
 # 最低要件
 
@@ -46,7 +47,7 @@ http://127.0.0.1:8001/
 
 ![Alt text](img/img01.png)
 
-次の画像をクリックすると youtube で応答速度を確認できます。
+次の画像をクリックすると YouTube で応答速度を確認できます。
 
 [![応答イメージ](img/img02.png)](https://youtu.be/h3-edtm-NLQ)
 
@@ -55,12 +56,12 @@ http://127.0.0.1:8001/
 - メインメモリ不足で言語モデル変換できない方は
   [huggingface](https://huggingface.co/sehiro/LINE-ct2-jp)
   から変換済のモデルをダウンロードしてください。
-  もっともメモリを使う「ct2-transformers-converter」コマンドの実行をスキップできます。
+  もっともメモリを使う `ct2-transformers-converter` コマンドの実行をスキップできます。
 
 - つよつよ CPU をお持ちの方は次のオプションを追加すると、AI エンジンがより高速に動作する可能性があります。（副作用として若干メインメモリの消費量が増えます）
 
 ```
-python main.py --aiengine=1 --maxspeed ON
+python main.py --aiengine=1 --maxspeed=ON
 ```
 
 
@@ -73,19 +74,23 @@ AI エンジンを llama.cpp に差し替えることで
 初心者にはかなりインストールのハードルが高いと思われるため、
 現状はソースを読んで理解できる方だけお使い頂けると…。
 
-- https://huggingface.co/mmnga/ELYZA-japanese-Llama-2-7b-fast-instruct-gguf
-からggufファイルをダウンロードして「models」フォルダに配置してください。
+- [huggingface](https://huggingface.co/mmnga/ELYZA-japanese-Llama-2-7b-fast-instruct-gguf)
+からggufファイルをダウンロードして `models` フォルダに配置してください。
 
 - コマンドプロンプト等から次のコマンドを入力してください
 
 ```
-pip install -r requirements-cpp.txt
+pip install -r requirements.txt
 python main.py
 ```
 
 ### 開発版を Docker で動かす
 
 ビルド環境を整えるのが難しい場合は Docker を使って起動できます。
+
+ [huggingface](https://huggingface.co/mmnga/ELYZA-japanese-Llama-2-7b-fast-instruct-gguf)から
+ モデル([ELYZA-japanese-Llama-2-7b-fast-instruct-q4_K_M.gguf](https://huggingface.co/mmnga/ELYZA-japanese-Llama-2-7b-fast-instruct-gguf/resolve/main/ELYZA-japanese-Llama-2-7b-fast-instruct-q4_K_M.gguf))を
+ ダウンロードして `models` フォルダに配置したあとに下記の手順で起動および終了してください。
 
 - 起動
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM ubuntu:23.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NOWARNINGS=yes
@@ -6,11 +6,13 @@ ENV DEBCONF_NOWARNINGS=yes
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get dist-upgrade -y && apt-get autoremove -y
 RUN apt-get install -y git build-essential
+RUN apt-get install -y python3 python3-venv
 
 RUN git clone https://github.com/sotokisehiro/chatux-server-llm.git /app
 WORKDIR /app
-RUN python -m pip install --upgrade pip
-RUN python -m pip install -r requirements.txt
+RUN python3 -m venv /venv
+RUN . /venv/bin/activate && python -m pip install --upgrade pip
+RUN . /venv/bin/activate && python -m pip install -r requirements.txt
 
 COPY ./docker/entrypoint.sh /
 RUN chmod 755 /entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,5 +5,6 @@ git fetch origin
 git switch main
 git pull origin main
 
-python3 main.py --aiengine=0 --listen="0.0.0.0" --maxspeed=ON
+source /venv/bin/activate
+python main.py --aiengine=0 --listen="0.0.0.0" --maxspeed=ON
 


### PR DESCRIPTION
`python:3.11-slim` を利用するメリットが低い(`build-essential` をインストールするために `apt update` をしているので冪等性がない)ため `ubuntu:23.04` を利用するように変更しました。

- root 権限でシステムグローバルな `pip install` を行うのは行儀が悪いということもあるので `/venv` に仮想環境を構築するようにしました。
- `README.md` の細かい修正をしました。

挙動がおかしいときは `docker compose build --no-cache` でキャッシュを無効にしてビルドしてください。