### PR TITLE
エンジンのユニットテストを追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ argparse
 peft
 tqdm
 llama-cpp-python<=0.2.5
+
+pytest

--- a/tests/test_ctranslate2.py
+++ b/tests/test_ctranslate2.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+
+from engine import CTranslate2Engine
+
+
+class TestCTranslate2Engine:
+    @pytest.fixture
+    def init_engine(self):
+        self.engine = CTranslate2Engine(os.cpu_count())
+
+    def test_self_introduction(self, init_engine):
+        res = self.engine.generate_text("自己紹介してください。")
+        print("res: {res}")
+        assert "アシスタント" in res

--- a/tests/test_ctranslate2.py
+++ b/tests/test_ctranslate2.py
@@ -12,5 +12,4 @@ class TestCTranslate2Engine:
 
     def test_self_introduction(self, init_engine):
         res = self.engine.generate_text("自己紹介してください。")
-        print("res: {res}")
         assert "アシスタント" in res

--- a/tests/test_llma_cpp.py
+++ b/tests/test_llma_cpp.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+
+from engine import LlamaCppEngine
+
+
+class TestLlamaCppEngine:
+    @pytest.fixture
+    def init_engine(self):
+        self.engine = LlamaCppEngine(os.cpu_count())
+
+    def test_self_introduction(self, init_engine):
+        res = self.engine.generate_text("自己紹介してください。")
+        print("res: {res}")
+        assert "ELYZA" in res

--- a/tests/test_llma_cpp.py
+++ b/tests/test_llma_cpp.py
@@ -12,5 +12,4 @@ class TestLlamaCppEngine:
 
     def test_self_introduction(self, init_engine):
         res = self.engine.generate_text("自己紹介してください。")
-        print("res: {res}")
         assert "ELYZA" in res


### PR DESCRIPTION
エンジンをモジュールに分割したのでモジュール単位でテストを書きました。

トップディレクトリで `pytest` や `python -m pytest` のコマンドで実行できます。

```
$ pytest
======================================================= test session starts ========================================================
platform darwin -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /Users/takano32/GitHub/chatux-server-llm
plugins: anyio-3.7.1
collected 2 items

tests/test_ctranslate2.py .                                                                                                  [ 50%]
tests/test_llma_cpp.py .                                                                                                     [100%]

================================================== 2 passed in 146.16s (0:02:26) ===================================================
```


テストがマージしてもらえたら、これを CI (GitHub Actions) で回して linux, macos, windows でビルドが通るのか、テストが通るのかを確認するワークフローを走らせたいと思っています。

ちょっとエンジンのテストに適切な入力と出力については調整がいるかもしれないです。
手元ではパスしていますが、確実にパスするかはわかりませんし、どんな入力にどんな出力が適切なのかを考えるのが難しかったです。
