### PR TITLE
Bind mounts to `/app/html` and `/app/line-sft`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,6 @@ services:
       - 8001:8001
     volumes:
       - ./models:/app/models
+      - ./line-sft:/app/line-sft
+      - ./html:/app/html
 


### PR DESCRIPTION
closes #8 

レポジトリの `./html` をコンテナの `/app/html` にバインドマウントする修正です。

修正後 `docker compose up` で起動したのちに、ローカルのファイルを修正するとコンテナの中のファイルが変更されて HTML の内容がカスタマイズできるようになったことを動作確認をしました。

`./models` を `/app/models` にマウントしているので `./line-sft` を `/app/line-sft` にマウントする変更も足しました。
この `line-sft` のマウントは Docker で `llama_cpp` だけではなく `ctranslate2` も切り替えて動作させることにもつながる修正です。
