### PR TITLE
Builderパターンの導入で抽象クラスのインスタンス化を廃止

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,5 +1,13 @@
+from engine.builder import CTranslate2EngineBuilder, Director, LlamaCppEngineBuilder
 from engine.ctranslate2 import CTranslate2Engine
 from engine.engine import Engine
 from engine.llama_cpp import LlamaCppEngine
 
-__all__ = ["Engine", "LlamaCppEngine", "CTranslate2Engine"]
+__all__ = [
+    "CTranslate2EngineBuilder",
+    "Director",
+    "LlamaCppEngineBuilder",
+    "Engine",
+    "LlamaCppEngine",
+    "CTranslate2Engine",
+]

--- a/engine/builder.py
+++ b/engine/builder.py
@@ -1,0 +1,39 @@
+from abc import ABC, abstractmethod
+
+from engine.ctranslate2 import CTranslate2Engine
+from engine.engine import Engine
+from engine.llama_cpp import LlamaCppEngine
+
+
+class EngineBuilder(ABC):
+    @abstractmethod
+    def get_engine(self) -> Engine:
+        raise NotImplementedError()
+
+
+class Director(object):
+    __builder = None
+
+    def set_builder(self, builder: EngineBuilder) -> None:
+        self.__builder = builder
+
+    def get_engine(self) -> Engine:
+        return self.__builder.get_engine()
+
+
+class LlamaCppEngineBuilder(EngineBuilder):
+    def __init__(self, cpu_thread=0) -> None:
+        self.cpu_thread = cpu_thread
+
+    def get_engine(self) -> LlamaCppEngine:
+        engine = LlamaCppEngine(self.cpu_thread)
+        return engine
+
+
+class CTranslate2EngineBuilder(EngineBuilder):
+    def __init__(self, cpu_thread=0) -> None:
+        self.cpu_thread = cpu_thread
+
+    def get_engine(self) -> CTranslate2Engine:
+        engine = CTranslate2Engine(self.cpu_thread)
+        return engine

--- a/engine/builder.py
+++ b/engine/builder.py
@@ -12,10 +12,8 @@ class EngineBuilder(ABC):
 
 
 class Director(object):
-    __builder = None
-
     def set_builder(self, builder: EngineBuilder) -> None:
-        self.__builder = builder
+        self.__builder: EngineBuilder = builder
 
     def get_engine(self) -> Engine:
         return self.__builder.get_engine()

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -1,6 +1,10 @@
-class Engine(object):
+from abc import ABC, abstractmethod
+
+
+class Engine(ABC):
     def __init__(self, cpu_thread=0) -> None:
         self.cpu_thread = cpu_thread
 
+    @abstractmethod
     def generate_text(self, input) -> str:
         raise NotImplementedError()

--- a/main.py
+++ b/main.py
@@ -7,7 +7,12 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
 from engine import Engine
-from engine.builder import CTranslate2EngineBuilder, Director, LlamaCppEngineBuilder
+from engine.builder import (
+    CTranslate2EngineBuilder,
+    Director,
+    EngineBuilder,
+    LlamaCppEngineBuilder,
+)
 
 # specify chat server
 HOST: str = "127.0.0.1"
@@ -55,13 +60,11 @@ director = Director()
 if SWITCH_AI_ENGINE == 0:
     # llama_cpp_python
     # ELYZA/Llama2系の生成エンジン).
-    builder = LlamaCppEngineBuilder(CPU_THREAD)
-    director.set_builder(builder)
+    director.set_builder(LlamaCppEngineBuilder(CPU_THREAD))
 else:
     # Ctranslate2
     # LINE生成エンジン.
-    builder = CTranslate2EngineBuilder(CPU_THREAD)
-    director.set_builder(builder)
+    director.set_builder(CTranslate2EngineBuilder(CPU_THREAD))
 
 engine: Engine = director.get_engine()
 app = FastAPI()

--- a/main.py
+++ b/main.py
@@ -6,7 +6,8 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
-from engine import CTranslate2Engine, Engine, LlamaCppEngine
+from engine import Engine
+from engine.builder import CTranslate2EngineBuilder, Director, LlamaCppEngineBuilder
 
 # specify chat server
 HOST: str = "127.0.0.1"
@@ -50,16 +51,19 @@ MODEL_NAME: str = args.modelname
 
 
 # 生成AIエンジンの初期化
-engine: Engine = Engine(CPU_THREAD)
+director = Director()
 if SWITCH_AI_ENGINE == 0:
     # llama_cpp_python
     # ELYZA/Llama2系の生成エンジン).
-    engine = LlamaCppEngine(CPU_THREAD)
+    builder = LlamaCppEngineBuilder(CPU_THREAD)
+    director.set_builder(builder)
 else:
     # Ctranslate2
     # LINE生成エンジン.
-    engine = CTranslate2Engine(CPU_THREAD)
+    builder = CTranslate2EngineBuilder(CPU_THREAD)
+    director.set_builder(builder)
 
+engine: Engine = director.get_engine()
 app = FastAPI()
 
 # Remove CORS restrictions (if needed)

--- a/main.py
+++ b/main.py
@@ -7,12 +7,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
 from engine import Engine
-from engine.builder import (
-    CTranslate2EngineBuilder,
-    Director,
-    EngineBuilder,
-    LlamaCppEngineBuilder,
-)
+from engine.builder import CTranslate2EngineBuilder, Director, LlamaCppEngineBuilder
 
 # specify chat server
 HOST: str = "127.0.0.1"


### PR DESCRIPTION
型の整合性をとるために抽象クラスをインスタンス化してしまっている箇所があり、それを修正する PR になります。

https://github.com/sotokisehiro/chatux-server-llm/blob/9518010baed3cc95bcabbc2f32e67db9f76c2a1f/main.py#L53

PR の内容はコードとしてはおそらく正しいのですが、取り込むと見通しが悪くなりそうなので修正するべき問題なのか迷っています。

Builder パターンの適用で抽象クラスのインスタンス化をしてしまう問題をなくしつつ、動作するコードは書けたのでいったん Draft で出します。

取り込むべきかは検討や議論が必要かもしれないと思っています。

可読性の低下によるデメリットが大きいなら抽象クラスの生成をしていてもその後で具象クラスに代入されているので無視するというのもありだと考えています。

GitHub Actions: https://github.com/takano32/chatux-server-llm/actions?query=branch%3AEngineBuilder