### PR TITLE
抽象クラスのインスタンス化を廃止

### DIFF
--- a/engine/engine.py
+++ b/engine/engine.py
@@ -1,6 +1,10 @@
-class Engine(object):
+from abc import ABC, abstractmethod
+
+
+class Engine(ABC):
     def __init__(self, cpu_thread=0) -> None:
         self.cpu_thread = cpu_thread
 
+    @abstractmethod
     def generate_text(self, input) -> str:
         raise NotImplementedError()

--- a/engine/llama_cpp.py
+++ b/engine/llama_cpp.py
@@ -34,4 +34,4 @@ class LlamaCppEngine(Engine):
             stop=["Instruction:", "Input:", "Response:"],
         )
 
-        return output["choices"][0]["text"]  # type: ignore
+        return output["choices"][0]["text"]  # type: ignore[index]

--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ MODEL_NAME: str = args.modelname
 
 
 # 生成AIエンジンの初期化
-engine_type: type[Engine] = Engine
+engine_type: type[Engine] = Engine  # type: ignore[type-abstract]
 if SWITCH_AI_ENGINE == 0:
     # llama_cpp_python
     # ELYZA/Llama2系の生成エンジン).

--- a/main.py
+++ b/main.py
@@ -50,15 +50,16 @@ MODEL_NAME: str = args.modelname
 
 
 # 生成AIエンジンの初期化
-engine: Engine = Engine(CPU_THREAD)
+engine_type: type[Engine] = Engine
 if SWITCH_AI_ENGINE == 0:
     # llama_cpp_python
     # ELYZA/Llama2系の生成エンジン).
-    engine = LlamaCppEngine(CPU_THREAD)
+    engine_type = LlamaCppEngine
 else:
     # Ctranslate2
     # LINE生成エンジン.
-    engine = CTranslate2Engine(CPU_THREAD)
+    engine_type = CTranslate2Engine
+engine = engine_type(CPU_THREAD)
 
 app = FastAPI()
 


### PR DESCRIPTION
closes #12 

#12 の提案があまりにおおげさなので、もう少し小さい変更で「抽象クラスをインスタンス化しない」方法を考えていたところ、型クラスを変数にもち、インスタンス化は避けて分岐で型クラスを代入して合流後にインスタンス化する方法を思いつきました。

比較的、小さい変更ながら整合性のある内容になっていると思いますので、これを PR として出します。

GitHub Actions: https://github.com/takano32/chatux-server-llm/actions?query=branch%3Aengine_type