### PR TITLE
組み込み関数と同じ名前の仮引数をリネーム

### DIFF
--- a/engine/ctranslate2.py
+++ b/engine/ctranslate2.py
@@ -21,8 +21,8 @@ class CTranslate2Engine(Engine):
         )
 
     # LINE用生成呼び出し
-    def generate_text(self, input) -> str:
-        prompt = "ユーザー :" + input + "システム :"
+    def generate_text(self, text_input: str) -> str:
+        prompt = "ユーザー :" + text_input + "システム :"
         tokens = self.tokenizer.convert_ids_to_tokens(
             self.tokenizer.encode(prompt, add_special_tokens=False)
         )

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -6,5 +6,5 @@ class Engine(ABC):
         self.cpu_thread = cpu_thread
 
     @abstractmethod
-    def generate_text(self, input) -> str:
+    def generate_text(self, text_input: str) -> str:
         raise NotImplementedError()

--- a/engine/llama_cpp.py
+++ b/engine/llama_cpp.py
@@ -14,15 +14,15 @@ class LlamaCppEngine(Engine):
         )
 
     # ELYZA用生成呼び出し
-    def generate_text(self, input) -> str:
-        B_INST, E_INST = "[INST]", "[/INST]"
-        B_SYS, E_SYS = "<<SYS>>\n", "\n<</SYS>>\n\n"
-        DEFAULT_SYSTEM_PROMPT = "あなたは誠実で優秀な日本人のアシスタントです。"
+    def generate_text(self, text_input: str) -> str:
+        B_INST, E_INST = "[INST]", "[/INST]"  # pylint: disable=invalid-name
+        B_SYS, E_SYS = "<<SYS>>\n", "\n<</SYS>>\n\n"  # pylint: disable=invalid-name
+        SYSTEM_PROMPT = "あなたは誠実で優秀な日本人のアシスタントです。"  # pylint: disable=invalid-name
 
         prompt = "{b_inst} {system}{prompt} {e_inst} ".format(
             b_inst=B_INST,
-            system=f"{B_SYS}{DEFAULT_SYSTEM_PROMPT}{E_SYS}",
-            prompt=input,
+            system=f"{B_SYS}{SYSTEM_PROMPT}{E_SYS}",
+            prompt=text_input,
             e_inst=E_INST,
         )
 

--- a/main.py
+++ b/main.py
@@ -50,16 +50,16 @@ MODEL_NAME: str = args.modelname
 
 
 # 生成AIエンジンの初期化
-engine_type: type[Engine] = Engine  # type: ignore[type-abstract]
+EngineType: type[Engine] = Engine  # type: ignore[type-abstract]
 if SWITCH_AI_ENGINE == 0:
     # llama_cpp_python
     # ELYZA/Llama2系の生成エンジン).
-    engine_type = LlamaCppEngine
+    EngineType = LlamaCppEngine
 else:
     # Ctranslate2
     # LINE生成エンジン.
-    engine_type = CTranslate2Engine
-engine = engine_type(CPU_THREAD)
+    EngineType = CTranslate2Engine
+engine = EngineType(CPU_THREAD)  # pylint: disable=abstract-class-instantiated
 
 app = FastAPI()
 


### PR DESCRIPTION
`input` が組み込み関数と同じ名前なので `text_input` という変数名に変更。

ref. https://docs.python.org/3/library/functions.html

他、検査についてのアノテーションを追記。